### PR TITLE
fix: correct company name spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@
 
 # DriveWealth's OpenAPI Specification
 
-This repository contains OpenAPI 3.0 definitions for DriveWalth's APIs. These OpenAPI description files enable code generation, test cases, and documentation.
+This repository contains OpenAPI 3.0 definitions for DriveWealth's APIs. These OpenAPI description files enable code generation, test cases, and documentation.
 
 This repository is in beta mode and we welcome community enagagement. Feel free to open an issue if there is something you want us to take a look at.

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@
 
 This repository contains OpenAPI 3.0 definitions for DriveWealth's APIs. These OpenAPI description files enable code generation, test cases, and documentation.
 
-This repository is in beta mode and we welcome community enagagement. Feel free to open an issue if there is something you want us to take a look at.
+This repository is in beta mode and we welcome community engagement. Feel free to open an issue if there is something you want us to take a look at.


### PR DESCRIPTION
I noticed a small typo in the README where "DriveWealth" is spelled as "DriveWeath". This PR fixes that typo.